### PR TITLE
Prevent a crash when the target URL doesn't contain "http"

### DIFF
--- a/BDDefaultBrowser.m
+++ b/BDDefaultBrowser.m
@@ -30,7 +30,11 @@
 }
 
 - (NSURL *)modifiedURL:(NSURL *)url {
-	NSString *strungURL = [[url absoluteString] substringFromIndex:[[url absoluteString] rangeOfString:@"http"].location];
+    NSInteger strungURLStartIndex = [[url absoluteString] rangeOfString:@"http"].location;
+    if (strungURLStartIndex == NSNotFound) {
+        return url;
+    }
+    NSString *strungURL = [[url absoluteString] substringFromIndex:strungURLStartIndex];
 	if(_percentEscapes) strungURL = [strungURL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]];
 	return [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", _scheme, strungURL]];
 }


### PR DESCRIPTION
This should fix the crash reported in #8 (which I also experienced) due to an NSRangeException being thrown in `modifiedURL:(NSURL*)url `, when `url` doesn't contain "http" and substringFromIndex is then called with NSNotFound as the start index.